### PR TITLE
fix typo on config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,13 +185,14 @@ spring:
         host: localhost
         port: 5672
     multirabbitmq:
-        connectionNameA:
-            defaultConnection: true
-            host: localhost
-            port: 5673
-        connectionNameB:
-            host: localhost
-            port: 5674
+        connections:
+            connectionNameA:
+                defaultConnection: true
+                host: localhost
+                port: 5672
+            connectionNameB:
+                host: localhost
+                port: 5672
 ```
 
 ## Compatibility of versions


### PR DESCRIPTION
Minor change to fix a typo on the example about how to set default multirabbitmq connection.