### PR TITLE
GH-18 Introduced workaround to guarantee initialization of ConnectionFactory when processing listeners

### DIFF
--- a/spring-multirabbit-examples/spring-multirabbit-example-java/src/main/java/com/mytaxi/spring/multirabbit/example/SomeListeners.java
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/src/main/java/com/mytaxi/spring/multirabbit/example/SomeListeners.java
@@ -13,6 +13,9 @@ class SomeListeners {
 
     private static final Logger LOG = LoggerFactory.getLogger(SomeListeners.class);
 
+    static final String CONNECTION_A = "connectionNameA";
+    static final String CONNECTION_B = "connectionNameB";
+
     private static final String SAMPLE_EXCHANGE = "sampleExchange";
     private static final String SAMPLE_ROUTING_KEY = "sampleRoutingKey";
     private static final String SAMPLE_QUEUE = "sampleQueue";
@@ -46,11 +49,10 @@ class SomeListeners {
      *
      * @param message the message received.
      */
-    @RabbitListener(containerFactory = "connectionNameA",
-            bindings = @QueueBinding(
-                    value = @Queue(SAMPLE_QUEUE_A),
-                    exchange = @Exchange(SAMPLE_EXCHANGE_A),
-                    key = SAMPLE_ROUTING_KEY_A))
+    @RabbitListener(containerFactory = CONNECTION_A, bindings = @QueueBinding(
+            value = @Queue(SAMPLE_QUEUE_A),
+            exchange = @Exchange(SAMPLE_EXCHANGE_A),
+            key = SAMPLE_ROUTING_KEY_A))
     void listenConnectionNameA(final String message) {
         LOG.info("Listener 'connectionNameA': {}", message);
     }
@@ -61,11 +63,10 @@ class SomeListeners {
      *
      * @param message the message received.
      */
-    @RabbitListener(containerFactory = "connectionNameB",
-            bindings = @QueueBinding(
-                    value = @Queue(SAMPLE_QUEUE_B),
-                    exchange = @Exchange(SAMPLE_EXCHANGE_B),
-                    key = SAMPLE_ROUTING_KEY_B))
+    @RabbitListener(containerFactory = CONNECTION_B, bindings = @QueueBinding(
+            value = @Queue(SAMPLE_QUEUE_B),
+            exchange = @Exchange(SAMPLE_EXCHANGE_B),
+            key = SAMPLE_ROUTING_KEY_B))
     public void listenConnectionNameB(final String message) {
         LOG.info("Listener 'connectionNameB': {}", message);
     }

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.java
@@ -1,0 +1,56 @@
+package com.mytaxi.spring.multirabbit.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class ConnectionFactoriesTest {
+
+    @Autowired
+    private ConnectionFactory connectionFactory;
+
+    @Value("${spring.rabbitmq.port}")
+    private int portDefaultConnection;
+
+    @Value("${spring.multirabbitmq.connectionNameA.port}")
+    private int portConnectionA;
+
+    @Value("${spring.multirabbitmq.connectionNameB.port}")
+    private int portConnectionB;
+
+    @Test
+    public void shouldLoadDefaultConnectionFactory() {
+        assertNotNull(connectionFactory);
+        assertEquals(portDefaultConnection, connectionFactory.getPort());
+    }
+
+    @Test
+    public void shouldLoadSecondaryConnectionFactoryA() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory connectionFactoryA = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.CONNECTION_A);
+        assertNotNull(connectionFactoryA);
+        assertEquals(portConnectionA, connectionFactoryA.getPort());
+    }
+
+    @Test
+    public void shouldLoadSecondaryConnectionFactoryB() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory connectionFactoryB = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.CONNECTION_B);
+        assertNotNull(connectionFactoryB);
+        assertEquals(portConnectionB, connectionFactoryB.getPort());
+    }
+}

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/mytaxi/spring/multirabbit/example/SomeListeners.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/mytaxi/spring/multirabbit/example/SomeListeners.kt
@@ -11,6 +11,9 @@ import org.springframework.stereotype.Component
 class SomeListeners {
 
     companion object : KLogging() {
+        const val CONNECTION_A: String = "connectionNameA"
+        const val CONNECTION_B: String = "connectionNameB"
+
         const val SAMPLE_EXCHANGE: String = "sampleExchange"
         const val SAMPLE_ROUTING_KEY: String = "sampleRoutingKey"
         const val SAMPLE_QUEUE: String = "sampleQueue"
@@ -44,7 +47,7 @@ class SomeListeners {
      *
      * @param message the message received.
      */
-    @RabbitListener(containerFactory = "connectionNameA", bindings = [(QueueBinding(
+    @RabbitListener(containerFactory = CONNECTION_A, bindings = [(QueueBinding(
             value = Queue(SAMPLE_QUEUE_A),
             exchange = Exchange(SAMPLE_EXCHANGE_A),
             key = arrayOf(SAMPLE_ROUTING_KEY_A)))])
@@ -58,7 +61,7 @@ class SomeListeners {
      *
      * @param message the message received.
      */
-    @RabbitListener(containerFactory = "connectionNameB", bindings = [(QueueBinding(
+    @RabbitListener(containerFactory = CONNECTION_B, bindings = [(QueueBinding(
             value = Queue(SAMPLE_QUEUE_B),
             exchange = Exchange(SAMPLE_EXCHANGE_B),
             key = arrayOf(SAMPLE_ROUTING_KEY_B)))])

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.kt
@@ -1,0 +1,54 @@
+package com.mytaxi.spring.multirabbit.example
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit4.SpringRunner
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+
+@SpringBootTest
+@RunWith(SpringRunner::class)
+class ConnectionFactoriesTest {
+
+    @Autowired
+    lateinit var connectionFactory: ConnectionFactory
+
+    @Value("\${spring.rabbitmq.port}")
+    private val portDefaultConnection: Int = 0
+
+    @Value("\${spring.multirabbitmq.connectionNameA.port}")
+    private val portConnectionA: Int = 0
+
+    @Value("\${spring.multirabbitmq.connectionNameB.port}")
+    private val portConnectionB: Int = 0
+
+    @Test
+    fun shouldLoadDefaultConnectionFactory() {
+        assertNotNull(connectionFactory)
+        assertEquals(portDefaultConnection, connectionFactory.port)
+    }
+
+    @Test
+    fun shouldLoadSecondaryConnectionFactoryA() {
+        val routingConnectionFactory = connectionFactory as SimpleRoutingConnectionFactory?
+        val connectionFactoryA = routingConnectionFactory!!
+                .getTargetConnectionFactory(SomeListeners.CONNECTION_A)
+        assertNotNull(connectionFactoryA)
+        assertEquals(portConnectionA, connectionFactoryA.port)
+    }
+
+    @Test
+    fun shouldLoadSecondaryConnectionFactoryB() {
+        val routingConnectionFactory = connectionFactory as SimpleRoutingConnectionFactory?
+        val connectionFactoryB = routingConnectionFactory!!
+                .getTargetConnectionFactory(SomeListeners.CONNECTION_B)
+        assertNotNull(connectionFactoryB)
+        assertEquals(portConnectionB, connectionFactoryB.port)
+    }
+}

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/main/java/com/mytaxi/spring/multirabbit/example/SomeListeners.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/main/java/com/mytaxi/spring/multirabbit/example/SomeListeners.java
@@ -13,6 +13,11 @@ class SomeListeners {
 
     private static final Logger LOG = LoggerFactory.getLogger(SomeListeners.class);
 
+    static final String CONNECTION_A = "connectionNameA";
+    static final String CONNECTION_B = "connectionNameB";
+    static final String EXTENDED_CONNECTION_A = "extendedConnectionNameA";
+    static final String EXTENDED_CONNECTION_B = "extendedConnectionNameB";
+
     private static final String SAMPLE_EXCHANGE = "sampleExchange";
     private static final String SAMPLE_ROUTING_KEY = "sampleRoutingKey";
     private static final String SAMPLE_QUEUE = "sampleQueue";

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/mytaxi/spring/multirabbit/example/ConnectionFactoriesTest.java
@@ -1,0 +1,56 @@
+package com.mytaxi.spring.multirabbit.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class ConnectionFactoriesTest {
+
+    @Autowired
+    private ConnectionFactory connectionFactory;
+
+    @Value("${spring.rabbitmq.port}")
+    private int portDefaultConnection;
+
+    @Value("${spring.multirabbitmq.connectionNameA.port}")
+    private int portConnectionA;
+
+    @Value("${spring.multirabbitmq.connectionNameB.port}")
+    private int portConnectionB;
+
+    @Test
+    public void shouldLoadDefaultConnectionFactory() {
+        assertNotNull(connectionFactory);
+        assertEquals(portDefaultConnection, connectionFactory.getPort());
+    }
+
+    @Test
+    public void shouldLoadSecondaryConnectionFactoryA() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory connectionFactoryA = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.CONNECTION_A);
+        assertNotNull(connectionFactoryA);
+        assertEquals(portConnectionA, connectionFactoryA.getPort());
+    }
+
+    @Test
+    public void shouldLoadSecondaryConnectionFactoryB() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory connectionFactoryB = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.CONNECTION_B);
+        assertNotNull(connectionFactoryB);
+        assertEquals(portConnectionB, connectionFactoryB.getPort());
+    }
+}

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/mytaxi/spring/multirabbit/example/ExtendedConnectionFactoriesTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/mytaxi/spring/multirabbit/example/ExtendedConnectionFactoriesTest.java
@@ -1,0 +1,37 @@
+package com.mytaxi.spring.multirabbit.example;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class ExtendedConnectionFactoriesTest {
+
+    @Autowired
+    private ConnectionFactory connectionFactory;
+
+    @Test
+    public void shouldLoadExtendedConnectionFactoryA() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory extendedConnectionFactoryA = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.EXTENDED_CONNECTION_A);
+        assertNotNull(extendedConnectionFactoryA);
+    }
+
+    @Test
+    public void shouldLoadExtendedConnectionFactoryB() {
+        final SimpleRoutingConnectionFactory routingConnectionFactory
+            = (SimpleRoutingConnectionFactory) connectionFactory;
+        final ConnectionFactory extendedConnectionFactoryB = routingConnectionFactory
+            .getTargetConnectionFactory(SomeListeners.EXTENDED_CONNECTION_B);
+        assertNotNull(extendedConnectionFactoryB);
+    }
+}

--- a/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
+++ b/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.Exchange;
-import org.springframework.amqp.rabbit.annotation.ExtendedRabbitListenerAnnotationBeanPostProcessor;
+import org.springframework.amqp.rabbit.annotation.MultiRabbitListenerAnnotationBeanPostProcessor;
 import org.springframework.amqp.rabbit.annotation.Queue;
 import org.springframework.amqp.rabbit.annotation.QueueBinding;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
@@ -77,7 +77,7 @@ public class BeansValidationTest {
     @Test
     public void shouldResolveExtendedRabbitListenerAnnotationBeanPostProcessor() {
         assertTrue(rabbitListenerAnnotationBeanPostProcessor
-                instanceof ExtendedRabbitListenerAnnotationBeanPostProcessor);
+                instanceof MultiRabbitListenerAnnotationBeanPostProcessor);
     }
 
     @RabbitListener(bindings = @QueueBinding(

--- a/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationWithListenerTest.java
+++ b/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationWithListenerTest.java
@@ -1,0 +1,81 @@
+package springframework.boot.autoconfigure.amqp;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
+import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.MultiRabbitConnectionFactoryWrapper;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class ExternalConfigurationWithListenerTest {
+
+    private static final String CONNECTION_KEY = "externalConnectionKey";
+    private static final int DEFAULT_CF_PORT = 10897;
+    private static final int EXTERNAL_CF_PORT = 20209;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Test
+    public void shouldLoadDefaultConnectionFactory() {
+        final ConnectionFactory connectionFactory
+            = applicationContext.getBean(SimpleRoutingConnectionFactory.class);
+        assertEquals(DEFAULT_CF_PORT, connectionFactory.getPort());
+    }
+
+    @Test
+    public void shouldLoadExternalConnectionFactory() {
+        final SimpleRoutingConnectionFactory connectionFactory
+            = applicationContext.getBean(SimpleRoutingConnectionFactory.class);
+        final ConnectionFactory externalConnectionFactory
+            = connectionFactory.getTargetConnectionFactory(CONNECTION_KEY);
+        assertNotNull(externalConnectionFactory);
+        assertEquals(EXTERNAL_CF_PORT, externalConnectionFactory.getPort());
+    }
+
+    @SpringBootApplication
+    @Import({MultiRabbitAutoConfiguration.class})
+    public static class SingleListenerApp {
+
+        @RabbitListener
+        public void onMessageDefaultConnectionFactory(final String event) {
+        }
+
+        @RabbitListener(containerFactory = CONNECTION_KEY)
+        public void onMessageExternalConnectionFactory(final String event) {
+        }
+
+        @Bean
+        @ConditionalOnClass(MultiRabbitConnectionFactoryWrapper.class)
+        static MultiRabbitConnectionFactoryWrapper externalWrapper() {
+            final ConnectionFactory defaultConnectionFactory = new CachingConnectionFactory(DEFAULT_CF_PORT);
+
+            final ConnectionFactory connectionFactory = new CachingConnectionFactory(EXTERNAL_CF_PORT);
+            final SimpleRabbitListenerContainerFactory containerFactory =
+                new SimpleRabbitListenerContainerFactory();
+            final RabbitAdmin rabbitAdmin = new RabbitAdmin(connectionFactory);
+
+            final MultiRabbitConnectionFactoryWrapper wrapper = new MultiRabbitConnectionFactoryWrapper();
+            wrapper.addConnectionFactory(CONNECTION_KEY, connectionFactory, containerFactory, rabbitAdmin);
+            wrapper.setDefaultConnectionFactory(defaultConnectionFactory);
+            return wrapper;
+        }
+    }
+}

--- a/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/SingleListenerTest.java
+++ b/spring-multirabbit-lib-integration/src/test/java/springframework/boot/autoconfigure/amqp/SingleListenerTest.java
@@ -1,0 +1,25 @@
+package springframework.boot.autoconfigure.amqp;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@SpringBootTest
+@RunWith(SpringRunner.class)
+public class SingleListenerTest {
+
+    @Test
+    public void loadListenerWithoutMentionToConnectionFactory() {
+    }
+
+    @SpringBootApplication
+    public static class SingleListenerApp {
+
+        @RabbitListener(containerFactory = "connectionNameA")
+        public void onMessage(final String event) {
+        }
+    }
+}

--- a/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfiguration.java
+++ b/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfiguration.java
@@ -8,13 +8,14 @@ import org.springframework.core.type.AnnotationMetadata;
 
 /**
  * An {@link ImportBeanDefinitionRegistrar} class that registers
- * a {@link ExtendedRabbitListenerAnnotationBeanPostProcessor} (overwriting the regular
+ * a {@link MultiRabbitListenerAnnotationBeanPostProcessor} (overwriting the regular
  * {@link RabbitListenerAnnotationBeanPostProcessor}) bean capable of processing
  * Spring's @{@link RabbitListener} annotation.
  *
  * @author Wander Costa
- * @see ExtendedRabbitListenerAnnotationBeanPostProcessor
+ * @see MultiRabbitListenerAnnotationBeanPostProcessor
  * @see RabbitListenerAnnotationBeanPostProcessor
+ * @see org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistry
  * @see EnableRabbit
  */
 public class MultiRabbitBootstrapConfiguration implements ImportBeanDefinitionRegistrar {
@@ -23,6 +24,6 @@ public class MultiRabbitBootstrapConfiguration implements ImportBeanDefinitionRe
     public void registerBeanDefinitions(final AnnotationMetadata importingClassMetadata,
                                         final BeanDefinitionRegistry registry) {
         registry.registerBeanDefinition(RabbitListenerConfigUtils.RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME,
-                new RootBeanDefinition(ExtendedRabbitListenerAnnotationBeanPostProcessor.class));
+                new RootBeanDefinition(MultiRabbitListenerAnnotationBeanPostProcessor.class));
     }
 }

--- a/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
@@ -4,31 +4,34 @@ import org.springframework.amqp.core.AbstractExchange;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.Declarable;
 import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import org.springframework.beans.factory.BeanFactory;
-import org.springframework.beans.factory.BeanFactoryAware;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 
 import java.lang.reflect.Method;
 
 /**
- * An extension of {@link RabbitListenerAnnotationBeanPostProcessor} that attaches the processing of beans
- * for Exchanges, Queues, and Bindings after they are created.
+ * An extension of {@link RabbitListenerAnnotationBeanPostProcessor} that attaches the processing of beans for
+ * Exchanges, Queues, and Bindings after they are created.
  * <p>
  * This processing enables each {@link RabbitAdmin} to differentiate which beans corresponds to that specific
- * {@link RabbitAdmin}, preventing the server from being populated with non-expected structures from other
- * servers.
+ * {@link RabbitAdmin}, preventing the server from being populated with non-expected structures from other servers.
+ *
+ * @author Wander Costa
+ * @see RabbitListenerAnnotationBeanPostProcessor
  */
-public class ExtendedRabbitListenerAnnotationBeanPostProcessor
+public final class MultiRabbitListenerAnnotationBeanPostProcessor
         extends RabbitListenerAnnotationBeanPostProcessor
-        implements ApplicationContextAware, BeanFactoryAware {
-
-    private static final String NO_ADMIN_BEAN_ERROR = "Bean '%s' not a RabbitAdmin. Cannot enhance beans with"
-            + "RabbitAdmin.";
+        implements ApplicationContextAware {
 
     private ApplicationContext applicationContext;
-    private BeanFactory beanFactory;
+
+    // TODO Remove this workaround. It ensures the ConnectionFactory is ready when the listeners
+    //  are processed by MultiRabbitListenerAnnotationBeanPostProcessor.
+    @Autowired
+    private ConnectionFactory connectionFactory;
 
     @Override
     protected void processAmqpListener(final RabbitListener rabbitListener,
@@ -43,34 +46,22 @@ public class ExtendedRabbitListenerAnnotationBeanPostProcessor
      * Enhance beans with related RabbitAdmin, so as to be filtered when being processed by the RabbitAdmin.
      */
     private void enhanceBeansWithReferenceToRabbitAdmin(final RabbitListener rabbitListener) {
-        final RabbitAdmin rabbitAdmin = getRabbitAdminBean(rabbitListener);
+        final String rabbitAdmin = RabbitAdminNameResolver.resolve(rabbitListener);
 
         // Enhance Exchanges
         applicationContext.getBeansOfType(AbstractExchange.class).values().stream()
                 .filter(this::isNotProcessed)
-                .forEach(exchange -> exchange.setAdminsThatShouldDeclare(rabbitAdmin != null ? rabbitAdmin : this));
+                .forEach(exchange -> exchange.setAdminsThatShouldDeclare(rabbitAdmin));
 
         // Enhance Queues
         applicationContext.getBeansOfType(Queue.class).values().stream()
                 .filter(this::isNotProcessed)
-                .forEach(queue -> queue.setAdminsThatShouldDeclare(rabbitAdmin != null ? rabbitAdmin : this));
+                .forEach(queue -> queue.setAdminsThatShouldDeclare(rabbitAdmin));
 
         // Enhance Bindings
         applicationContext.getBeansOfType(Binding.class).values().stream()
                 .filter(this::isNotProcessed)
-                .forEach(binding -> binding.setAdminsThatShouldDeclare(rabbitAdmin != null ? rabbitAdmin : this));
-    }
-
-    /**
-     * Returns the RabbitAdmin bean of the requested name or the default one.
-     */
-    private RabbitAdmin getRabbitAdminBean(final RabbitListener rabbitListener) {
-        final String name = RabbitAdminNameResolver.resolve(rabbitListener);
-        final Object rabbitAdmin = beanFactory.getBean(name);
-        if (!(rabbitAdmin instanceof RabbitAdmin)) {
-            throw new IllegalStateException(String.format(NO_ADMIN_BEAN_ERROR, name));
-        }
-        return (RabbitAdmin) rabbitAdmin;
+                .forEach(binding -> binding.setAdminsThatShouldDeclare(rabbitAdmin));
     }
 
     /**
@@ -80,12 +71,6 @@ public class ExtendedRabbitListenerAnnotationBeanPostProcessor
         return declarable.getDeclaringAdmins() == null
                 || (declarable.getDeclaringAdmins().stream().noneMatch(item -> item == this)
                 && declarable.getDeclaringAdmins().stream().noneMatch(item -> item instanceof RabbitAdmin));
-    }
-
-    @Override
-    public void setBeanFactory(final BeanFactory beanFactory) {
-        this.beanFactory = beanFactory;
-        super.setBeanFactory(beanFactory);
     }
 
     @Override

--- a/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-multirabbit-lib/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
@@ -28,8 +28,6 @@ public final class MultiRabbitListenerAnnotationBeanPostProcessor
 
     private ApplicationContext applicationContext;
 
-    // TODO Remove this workaround. It ensures the ConnectionFactory is ready when the listeners
-    //  are processed by MultiRabbitListenerAnnotationBeanPostProcessor.
     @Autowired
     private ConnectionFactory connectionFactory;
 

--- a/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfigurationTest.java
+++ b/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfigurationTest.java
@@ -23,6 +23,6 @@ public class MultiRabbitBootstrapConfigurationTest {
         configuration.registerBeanDefinitions(null, registry);
 
         verify(registry).registerBeanDefinition(RABBIT_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME,
-                new RootBeanDefinition(ExtendedRabbitListenerAnnotationBeanPostProcessor.class));
+                new RootBeanDefinition(MultiRabbitListenerAnnotationBeanPostProcessor.class));
     }
 }


### PR DESCRIPTION
This PR addresses the late initialization of the ConnectionFactories, which are necessary for the Listeners to be processed in the current implementation.

Current implementation might have been different if we could retrieve the Declarables from the underlying BeanPostProcessor (which was recently contributed to the framework). Therefore, in the framework, this would not be necessary.

Replicating to 2.1 the changes in https://github.com/freenowtech/spring-multirabbit/pull/20