### PR TITLE
unbind connection factory should use surround with try & finally

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,11 @@ private RabbitTemplate rabbitTemplate;
 
 void someMethod() {
     SimpleResourceHolder.bind(rabbitTemplate.getConnectionFactory(), "connectionNameA");
-    rabbitTemplate.convertAndSend("someExchange", "someRoutingKey", "someMessage"); // Use RabbitTemplate
-    SimpleResourceHolder.unbind(rabbitTemplate.getConnectionFactory());
+    try {
+        rabbitTemplate.convertAndSend("someExchange", "someRoutingKey", "someMessage"); // Use RabbitTemplate
+    } finally {
+        SimpleResourceHolder.unbind(rabbitTemplate.getConnectionFactory());
+    }
 }
 ```
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/src/main/java/com/mytaxi/spring/multirabbit/example/SomeController.java
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/src/main/java/com/mytaxi/spring/multirabbit/example/SomeController.java
@@ -54,13 +54,14 @@ class SomeController {
 
         final String exchange = EXCHANGE_NAME + id;
         final String routingKey = ROUTING_KEY + id;
-
-        // Regular use of RabbitTemplate
-        rabbitTemplate.convertAndSend(exchange, routingKey, message);
-
-        // Unbinding the context of Rabbit ConnectionFactory
-        if (!id.isEmpty()) {
-            SimpleResourceHolder.unbind(rabbitTemplate.getConnectionFactory());
+        try {
+            // Regular use of RabbitTemplate
+            rabbitTemplate.convertAndSend(exchange, routingKey, message);
+        } finally {
+            // Unbinding the context of Rabbit ConnectionFactory
+            if (!id.isEmpty()) {
+                SimpleResourceHolder.unbind(rabbitTemplate.getConnectionFactory());
+            }
         }
     }
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/mytaxi/spring/multirabbit/example/SomeController.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/mytaxi/spring/multirabbit/example/SomeController.kt
@@ -44,13 +44,14 @@ class SomeController(var rabbitTemplate: RabbitTemplate,
 
         val exchange = EXCHANGE_NAME + emptyIfNull(id)
         val routingKey = ROUTING_KEY + emptyIfNull(id)
-
-        // Regular use of RabbitTemplate
-        rabbitTemplate.convertAndSend(exchange, routingKey, message)
-
-        // Unbinding the context of Rabbit ConnectionFactory
-        if (!isEmpty(id)) {
-            SimpleResourceHolder.unbind(rabbitTemplate.connectionFactory)
+        try {
+            // Regular use of RabbitTemplate
+            rabbitTemplate.convertAndSend(exchange, routingKey, message)
+        } finally {
+            // Unbinding the context of Rabbit ConnectionFactory
+            if (!isEmpty(id)) {
+                SimpleResourceHolder.unbind(rabbitTemplate.connectionFactory)
+            }
         }
     }
 


### PR DESCRIPTION
Unbind connection factory should use surround with try & finally.

When the exception occurs before unbind(), the thread does not clean up the bind resources, and there will be routing to the old resources or java.lang.IllegalArgumentException exceptions when next bind() call.

```
14:52:54.493 "http-nio-30111-exec-3" INFO  "d16b7c802978d8b7" "d16b7c802978d8b7" "" com.heytea.starter.autoconfigure.config.BaseGlobalExceptionHandler 
java.lang.IllegalArgumentException: Already value [internal-system] for key [org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory@62e0f621] bound to thread [http-nio-30111-exec-3]
	at org.springframework.util.Assert.isNull(Assert.java:176)
	at org.springframework.amqp.rabbit.connection.SimpleResourceHolder.bind(SimpleResourceHolder.java:133)
        ...
```