### PR TITLE
GH-18 Injecting admin at RabbitListener so as be resolved for the RabbitListenerEndpoint

### DIFF
--- a/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
+++ b/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
@@ -1,0 +1,61 @@
+package org.springframework.amqp.rabbit.annotation;
+
+import org.junit.Test;
+import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link MultiRabbitAutoConfiguration} is normally triggered before the processing of the Listeners by the
+ * {@link MultiRabbitListenerAnnotationBeanPostProcessor}. However, this does not happen whenever there is no injection
+ * of {@link org.springframework.amqp.rabbit.connection.ConnectionFactory}.
+ * This test makes sure to test MultiRabbit without the injection of a RabbitTemplate as a workaround for the
+ * initialization.
+ */
+public class AutoConfigInitializationTest {
+
+    @Test
+    public void shouldStartContextWithoutRabbitTemplate() {
+        final AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
+                ThreeBrokersConfig.class, RabbitAutoConfiguration.class, MultiRabbitAutoConfiguration.class,
+                ListenerBeans.class);
+        ctx.close(); // Close and stop the listeners
+    }
+
+    @Component
+    @EnableRabbit
+    private static class ListenerBeans {
+
+        @RabbitListener(bindings = @QueueBinding(
+                exchange = @Exchange("exchange0"),
+                value = @Queue(),
+                key = "routingKey0"))
+        void listenBroker0(final String message) {
+        }
+
+        @RabbitListener(containerFactory = "broker1", bindings = @QueueBinding(
+                exchange = @Exchange("exchange1"),
+                value = @Queue(),
+                key = "routingKey1"))
+        void listenBroker1(final String message) {
+        }
+
+        @RabbitListener(containerFactory = "broker2", bindings = @QueueBinding(
+                exchange = @Exchange("exchange2"),
+                value = @Queue(),
+                key = "routingKey2"))
+        void listenBroker2(final String message) {
+        }
+    }
+
+    /**
+     * Configuration to provide 3 brokers.
+     */
+    @Configuration
+    @PropertySource("classpath:application-three-brokers.properties")
+    public static class ThreeBrokersConfig {
+    }
+}

--- a/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
+++ b/spring-multirabbit-lib/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 public class AutoConfigInitializationTest {
 
     @Test
-    public void shouldStartContextWithoutRabbitTemplate() {
+    public void shouldStartContextWithoutConnectionFactory() {
         final AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(
                 ThreeBrokersConfig.class, RabbitAutoConfiguration.class, MultiRabbitAutoConfiguration.class,
                 ListenerBeans.class);

--- a/spring-multirabbit-lib/src/test/resources/application-three-brokers.properties
+++ b/spring-multirabbit-lib/src/test/resources/application-three-brokers.properties
@@ -1,0 +1,4 @@
+spring.rabbitmq.port=5672
+spring.multirabbitmq.enabled=true
+spring.multirabbitmq.connections.broker1.port=5673
+spring.multirabbitmq.connections.broker2.port=5674


### PR DESCRIPTION
# Description

This PR injects the RabbitAdmin to be resolved by the underlying implementation of the RabbitListenerAnnotationBPP and be used in the MethodRabbitListenerEndpoint.

This fixes the initialization bug, where the listeners didn't find the proper bean unless the `ConnectionFactory` bean (or another transitive dependency bean) is injected.