### PR TITLE
Compatibility with Spring Boot 2.4.3

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -5,13 +5,15 @@ on:
     branches:
       - main
       - release/**
+      - develop/**
   pull_request:
     branches:
       - main
       - release/**
+      - develop/**
 
 jobs:
-  java8:
+  java:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -20,8 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup java
-        uses: actions/setup-java@v1
+        uses: joschi/setup-jdk@v2
         with:
           java-version: ${{ matrix.java }}
+          architecture: x64
       - run: java -version
-      - run: mvn -B verify --file pom.xml
+      - run: mvn -v
+      - run: mvn -B verify

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Spring MultiRabbit
+
+[![Latest release](https://img.shields.io/github/release/freenowtech/spring-multirabbit.svg)](https://github.com/freenowtech/spring-multirabbit/releases/latest)
+![Build Status](https://github.com/freenowtech/spring-multirabbit/actions/workflows/maven.yml/badge.svg)
+
 **Spring MultiRabbit** is a library to enable multiple RabbitMQ brokers in SpringBoot applications. The modules are:
 * **spring-multirabbit** - the main module, that provides the auto-configuration feature;
 * **spring-multirabbit-integration** - a module to test integration with Spring;

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.3.9.RELEASE</springboot.version>
+        <springboot.version>2.4.3</springboot.version>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.0</version>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -122,6 +122,35 @@
                         <goals>
                             <goal>check</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                    <excludes>
+                        <exclude>**/*IntegrationTest.java</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>integration-test</id>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <phase>integration-test</phase>
+                        <configuration>
+                            <excludes>
+                                <exclude>none</exclude>
+                            </excludes>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                                <include>**/*TestSuite.java</include>
+                            </includes>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -33,11 +33,6 @@
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.9.RELEASE</version>
+        <version>2.4.3</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -43,6 +43,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
@@ -1,20 +1,17 @@
 package com.freenow.multirabbit.example;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
-@RunWith(SpringRunner.class)
-public class ApplicationTest {
+class ApplicationTest {
 
     @Autowired
     private ConnectionFactory connectionFactory;
@@ -23,13 +20,13 @@ public class ApplicationTest {
     private RabbitListenerAnnotationBeanPostProcessor rabbitListenerAnnotationBeanPostProcessor;
 
     @Test
-    public void shouldLoadConnectionFactoryBean() {
+    void shouldLoadConnectionFactoryBean() {
         assertNotNull(connectionFactory);
         assertTrue(connectionFactory instanceof SimpleRoutingConnectionFactory);
     }
 
     @Test
-    public void shouldLoadRabbitListenerAnnotationBeanPostProcessorBean() {
+    void shouldLoadRabbitListenerAnnotationBeanPostProcessorBean() {
         assertNotNull(rabbitListenerAnnotationBeanPostProcessor);
     }
 }

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
@@ -1,16 +1,19 @@
 package com.freenow.multirabbit.example;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
+@ExtendWith(SpringExtension.class)
 class ApplicationTest {
 
     @Autowired

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -46,14 +46,14 @@
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.github.microutils</groupId>
             <artifactId>kotlin-logging</artifactId>
             <version>1.5.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -61,6 +61,16 @@
         <sourceDirectory>src/main/kotlin</sourceDirectory>
         <testSourceDirectory>src/test/kotlin</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.9.RELEASE</version>
+        <version>2.4.3</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -45,12 +45,6 @@
             <groupId>com.fasterxml.jackson.module</groupId>
             <artifactId>jackson-module-kotlin</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/freenow/multirabbit/example/SomeController.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/main/kotlin/com/freenow/multirabbit/example/SomeController.kt
@@ -3,7 +3,7 @@ package com.freenow.multirabbit.example
 import org.springframework.amqp.rabbit.connection.SimpleResourceHolder
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.boot.autoconfigure.amqp.ConnectionFactoryContextWrapper
-import org.springframework.util.StringUtils.isEmpty
+import org.springframework.util.StringUtils.hasLength
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -38,7 +38,7 @@ class SomeController(var rabbitTemplate: RabbitTemplate,
      */
     private fun sendMessageTheDefaultWay(message: String, id: String?) {
         // Binding to the right context of Rabbit ConnectionFactory
-        if (!isEmpty(id)) {
+        if (hasLength(id)) {
             SimpleResourceHolder.bind(rabbitTemplate.connectionFactory, CONNECTION_PREFIX + emptyIfNull(id))
         }
 
@@ -49,7 +49,7 @@ class SomeController(var rabbitTemplate: RabbitTemplate,
             rabbitTemplate.convertAndSend(exchange, routingKey, message)
         } finally {
             // Unbinding the context of Rabbit ConnectionFactory
-            if (!isEmpty(id)) {
+            if (hasLength(id)) {
                 SimpleResourceHolder.unbind(rabbitTemplate.connectionFactory)
             }
         }
@@ -59,7 +59,7 @@ class SomeController(var rabbitTemplate: RabbitTemplate,
      * Sends a message using the context wrapper.
      */
     private fun sendMessageUsingContextWrapper(message: String, id: String?) {
-        val idWithPrefix = if (!isEmpty(id)) CONNECTION_PREFIX + id else null
+        val idWithPrefix = if (hasLength(id)) CONNECTION_PREFIX + id else null
         contextWrapper.run(idWithPrefix, {
             val exchange = EXCHANGE_NAME + emptyIfNull(id)
             val routingKey = ROUTING_KEY + emptyIfNull(id)

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/freenow/multirabbit/example/ApplicationTest.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/freenow/multirabbit/example/ApplicationTest.kt
@@ -1,17 +1,14 @@
 package com.freenow.multirabbit.example
 
-import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertTrue
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.junit4.SpringRunner
 
-@RunWith(SpringRunner::class)
 @SpringBootTest(classes = [Application::class])
 class ApplicationTest {
 

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/freenow/multirabbit/example/ApplicationTest.kt
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/src/test/kotlin/com/freenow/multirabbit/example/ApplicationTest.kt
@@ -3,12 +3,15 @@ package com.freenow.multirabbit.example
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
 import org.springframework.amqp.rabbit.connection.SimpleRoutingConnectionFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.junit.jupiter.SpringExtension
 
+@ExtendWith(SpringExtension::class)
 @SpringBootTest(classes = [Application::class])
 class ApplicationTest {
 

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -37,12 +37,6 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -48,6 +48,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.9.RELEASE</version>
+        <version>2.4.3</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
@@ -1,6 +1,7 @@
 package com.freenow.multirabbit.example;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -10,14 +11,18 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitConstants;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import java.util.Arrays;
 import java.util.List;
+
 import static com.freenow.multirabbit.example.ExtendedConfiguration.EXTENDED_CONNECTION_A;
 import static com.freenow.multirabbit.example.ExtendedConfiguration.EXTENDED_CONNECTION_B;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
+@ExtendWith(SpringExtension.class)
 class ApplicationTest {
 
     @Autowired

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/ApplicationTest.java
@@ -1,7 +1,6 @@
 package com.freenow.multirabbit.example;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.annotation.RabbitListenerAnnotationBeanPostProcessor;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -11,19 +10,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitConstants;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import java.util.Arrays;
 import java.util.List;
-
 import static com.freenow.multirabbit.example.ExtendedConfiguration.EXTENDED_CONNECTION_A;
 import static com.freenow.multirabbit.example.ExtendedConfiguration.EXTENDED_CONNECTION_B;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringBootTest
-@RunWith(SpringRunner.class)
-public class ApplicationTest {
+class ApplicationTest {
 
     @Autowired
     private ConnectionFactory connectionFactory;
@@ -35,18 +30,18 @@ public class ApplicationTest {
     private ApplicationContext applicationContext;
 
     @Test
-    public void shouldLoadConnectionFactoryBean() {
+    void shouldLoadConnectionFactoryBean() {
         assertNotNull(connectionFactory);
         assertTrue(connectionFactory instanceof SimpleRoutingConnectionFactory);
     }
 
     @Test
-    public void shouldLoadRabbitListenerAnnotationBeanPostProcessorBean() {
+    void shouldLoadRabbitListenerAnnotationBeanPostProcessorBean() {
         assertNotNull(rabbitListenerAnnotationBeanPostProcessor);
     }
 
     @Test
-    public void shouldResolveContainerFactoryBeans() {
+    void shouldResolveContainerFactoryBeans() {
         List<String> beans = Arrays.asList(applicationContext
                 .getBeanNamesForType(SimpleRabbitListenerContainerFactory.class));
         assertTrue(beans.containsAll(Arrays.asList("rabbitListenerContainerFactory", EXTENDED_CONNECTION_A,
@@ -56,7 +51,7 @@ public class ApplicationTest {
     }
 
     @Test
-    public void shouldResolveRabbitAdminBeans() {
+    void shouldResolveRabbitAdminBeans() {
         List<String> beans = Arrays.asList(applicationContext.getBeanNamesForType(RabbitAdmin.class));
         assertTrue(beans.containsAll(Arrays.asList(
                 MultiRabbitConstants.DEFAULT_RABBIT_ADMIN_BEAN_NAME,

--- a/spring-multirabbit-integration/pom.xml
+++ b/spring-multirabbit-integration/pom.xml
@@ -13,7 +13,7 @@
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-integration</artifactId>
     <version>2.3.1-SNAPSHOT</version>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <name>Spring MultiRabbit Library Integration Tests</name>
     <description>Module for integration tests with a running SpringBoot instance</description>

--- a/spring-multirabbit-integration/pom.xml
+++ b/spring-multirabbit-integration/pom.xml
@@ -38,11 +38,6 @@
             <artifactId>spring-boot-starter-amqp</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/spring-multirabbit-integration/pom.xml
+++ b/spring-multirabbit-integration/pom.xml
@@ -48,6 +48,16 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
                 <configuration>
                     <skip>true</skip>

--- a/spring-multirabbit-integration/pom.xml
+++ b/spring-multirabbit-integration/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.9.RELEASE</version>
+        <version>2.4.3</version>
         <relativePath />
     </parent>
 

--- a/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
+++ b/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
@@ -1,6 +1,7 @@
 package springframework.boot.autoconfigure.amqp;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.Exchange;
 import org.springframework.amqp.rabbit.annotation.MultiRabbitListenerAnnotationBeanPostProcessor;
@@ -18,6 +19,8 @@ import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitConstants;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
 import java.util.Arrays;
 import java.util.List;
 
@@ -25,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRabbit
+@ExtendWith(SpringExtension.class)
+@SuppressWarnings("EmptyMethod")
 @SpringBootTest(classes = MultiRabbitAutoConfiguration.class)
 class BeansValidationTest {
 

--- a/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
+++ b/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/BeansValidationTest.java
@@ -1,7 +1,6 @@
 package springframework.boot.autoconfigure.amqp;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.annotation.Exchange;
 import org.springframework.amqp.rabbit.annotation.MultiRabbitListenerAnnotationBeanPostProcessor;
@@ -19,19 +18,15 @@ import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitConstants;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationContext;
-import org.springframework.test.context.junit4.SpringRunner;
-
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @EnableRabbit
-@RunWith(SpringRunner.class)
-@SuppressWarnings("EmptyMethod")
 @SpringBootTest(classes = MultiRabbitAutoConfiguration.class)
-public class BeansValidationTest {
+class BeansValidationTest {
 
     private static final String CONNECTION_A = "connectionNameA";
     private static final String CONNECTION_B = "connectionNameB";
@@ -46,12 +41,12 @@ public class BeansValidationTest {
     private RabbitListenerAnnotationBeanPostProcessor rabbitListenerAnnotationBeanPostProcessor;
 
     @Test
-    public void shouldResolveSimpleRoutingConnectionFactoryBean() {
+    void shouldResolveSimpleRoutingConnectionFactoryBean() {
         assertTrue(connectionFactory instanceof SimpleRoutingConnectionFactory);
     }
 
     @Test
-    public void shouldResolveContainerFactoryBeans() {
+    void shouldResolveContainerFactoryBeans() {
         List<String> beans = Arrays.asList(applicationContext
                 .getBeanNamesForType(SimpleRabbitListenerContainerFactory.class));
         assertTrue(beans.containsAll(Arrays.asList("rabbitListenerContainerFactory", CONNECTION_A, CONNECTION_B)));
@@ -60,12 +55,12 @@ public class BeansValidationTest {
     }
 
     @Test
-    public void shouldResolveConnectionFactoryContextWrapper() {
+    void shouldResolveConnectionFactoryContextWrapper() {
         assertNotNull(applicationContext.getBean(ConnectionFactoryContextWrapper.class));
     }
 
     @Test
-    public void shouldResolveRabbitAdminBeans() {
+    void shouldResolveRabbitAdminBeans() {
         List<String> beans = Arrays.asList(applicationContext.getBeanNamesForType(RabbitAdmin.class));
         assertTrue(beans.containsAll(Arrays.asList(
                 MultiRabbitConstants.DEFAULT_RABBIT_ADMIN_BEAN_NAME,
@@ -75,7 +70,7 @@ public class BeansValidationTest {
     }
 
     @Test
-    public void shouldResolveExtendedRabbitListenerAnnotationBeanPostProcessor() {
+    void shouldResolveExtendedRabbitListenerAnnotationBeanPostProcessor() {
         assertTrue(rabbitListenerAnnotationBeanPostProcessor instanceof MultiRabbitListenerAnnotationBeanPostProcessor);
     }
 

--- a/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
+++ b/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
@@ -2,6 +2,7 @@ package springframework.boot.autoconfigure.amqp;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -16,6 +17,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -24,8 +26,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @EnableRabbit
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = ExternalConfigurationTest.Config.class)
-public class ExternalConfigurationTest {
+class ExternalConfigurationTest {
 
     private static final String CONNECTION_KEY = "externalConnectionKey";
     private static final ConnectionFactory CONNECTION_FACTORY = mock(ConnectionFactory.class);
@@ -42,7 +45,7 @@ public class ExternalConfigurationTest {
 
     @AfterEach
     void after() {
-        // For the sake of simplicity, the mocks are static so as to be shared between classes.
+        // For the sake of simplicity, the mocks are static so as to be shared among classes.
         // Thus, they need to reset after using, to avoid interferences on the next test.
         reset(CONNECTION_FACTORY, CONTAINER_FACTORY, RABBIT_ADMIN);
     }

--- a/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
+++ b/spring-multirabbit-integration/src/test/java/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
@@ -1,8 +1,7 @@
 package springframework.boot.autoconfigure.amqp;
 
-import org.junit.After;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.annotation.EnableRabbit;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -17,7 +16,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -26,7 +24,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @EnableRabbit
-@RunWith(SpringRunner.class)
 @SpringBootTest(classes = ExternalConfigurationTest.Config.class)
 public class ExternalConfigurationTest {
 
@@ -43,21 +40,21 @@ public class ExternalConfigurationTest {
     @Autowired
     private MultiRabbitProperties multiRabbitProperties;
 
-    @After
-    public void after() {
+    @AfterEach
+    void after() {
         // For the sake of simplicity, the mocks are static so as to be shared between classes.
         // Thus, they need to reset after using, to avoid interferences on the next test.
         reset(CONNECTION_FACTORY, CONTAINER_FACTORY, RABBIT_ADMIN);
     }
 
     @Test
-    public void shouldResolveDefaultExternalConnectionFactory() {
+    void shouldResolveDefaultExternalConnectionFactory() {
         connectionFactory.getVirtualHost();
         verify(DEFAULT_CONNECTION_FACTORY).getVirtualHost();
     }
 
     @Test
-    public void shouldResolveExternalConnectionFactory() {
+    void shouldResolveExternalConnectionFactory() {
         SimpleResourceHolder.bind(connectionFactory, CONNECTION_KEY);
         connectionFactory.getVirtualHost();
         SimpleResourceHolder.unbind(connectionFactory);
@@ -65,7 +62,7 @@ public class ExternalConfigurationTest {
     }
 
     @Test
-    public void shouldResolveExistentConnectionFactoriesFromMulti() {
+    void shouldResolveExistentConnectionFactoriesFromMulti() {
         multiRabbitProperties.getConnections().keySet().forEach(key -> {
             SimpleResourceHolder.bind(connectionFactory, key);
             connectionFactory.getVirtualHost();

--- a/spring-multirabbit/pom.xml
+++ b/spring-multirabbit/pom.xml
@@ -37,23 +37,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-multirabbit/pom.xml
+++ b/spring-multirabbit/pom.xml
@@ -31,19 +31,13 @@
             <artifactId>validation-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.collections</groupId>
-            <artifactId>google-collections</artifactId>
-            <version>1.0-rc5</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-test</artifactId>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/spring-multirabbit/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
+++ b/spring-multirabbit/src/main/java/org/springframework/amqp/rabbit/annotation/MultiRabbitListenerAnnotationBeanPostProcessor.java
@@ -4,6 +4,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.util.Collection;
 import org.springframework.amqp.core.AbstractDeclarable;
 import org.springframework.amqp.core.Declarable;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
@@ -28,16 +29,17 @@ public final class MultiRabbitListenerAnnotationBeanPostProcessor
     private ApplicationContext applicationContext;
 
     @Override
-    protected void processAmqpListener(final RabbitListener rabbitListener,
+    protected Collection<Declarable> processAmqpListener(final RabbitListener rabbitListener,
                                        final Method method,
                                        final Object bean,
                                        final String beanName) {
         final String rabbitAdmin = RabbitAdminNameResolver.resolve(rabbitListener);
         final RabbitListener rabbitListenerRef = proxyIfAdminNotPresent(rabbitListener, rabbitAdmin);
-        super.processAmqpListener(rabbitListenerRef, method, bean, beanName);
+        Collection<Declarable> declarables = super.processAmqpListener(rabbitListenerRef, method, bean, beanName);
         applicationContext.getBeansOfType(AbstractDeclarable.class).values().stream()
                 .filter(this::isNotProcessed)
                 .forEach(exchange -> exchange.setAdminsThatShouldDeclare(rabbitAdmin));
+        return declarables;
     }
 
     private RabbitListener proxyIfAdminNotPresent(final RabbitListener rabbitListener, final String rabbitAdmin) {

--- a/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
+++ b/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
@@ -141,7 +141,7 @@ public class MultiRabbitAutoConfiguration {
          * @param multiRabbitProperties The additional rabbit properties.
          * @param externalWrapper       The external wrapper for integration.
          * @return The routing connection factory.
-         * @throws IllegalArgumentException if default connection factory is not found.
+         * @throws Exception (IllegalArgumentException) if default connection factory is not found.
          */
         @Primary
         @Bean(MultiRabbitConstants.CONNECTION_FACTORY_BEAN_NAME)

--- a/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
+++ b/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfiguration.java
@@ -126,7 +126,7 @@ public class MultiRabbitAutoConfiguration {
         /**
          * Returns the empty wrapper if non is provided.
          *
-         * @return  the empty wrapper if non is provided.
+         * @return the empty wrapper if non is provided.
          */
         @Bean
         @ConditionalOnMissingBean

--- a/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
@@ -1,5 +1,6 @@
 package org.springframework.amqp.rabbit.annotation;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
@@ -18,6 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * This test makes sure to test MultiRabbit without the injection of a RabbitTemplate as a workaround for the
  * initialization.
  */
+// TODO https://github.com/freenowtech/spring-multirabbit/issues/49
+@Disabled
 class AutoConfigInitializationTest {
 
     private static final int ADMINS = 3;

--- a/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/AutoConfigInitializationTest.java
@@ -1,7 +1,5 @@
 package org.springframework.amqp.rabbit.annotation;
 
-import static org.junit.Assert.assertEquals;
-
 import org.junit.jupiter.api.Test;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitAutoConfiguration;
@@ -10,6 +8,8 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.stereotype.Component;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * {@link MultiRabbitAutoConfiguration} is normally triggered before the processing of the Listeners by the

--- a/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfigurationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitBootstrapConfigurationTest.java
@@ -1,25 +1,25 @@
 package org.springframework.amqp.rabbit.annotation;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.config.RabbitListenerConfigUtils;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 
 import static org.mockito.Mockito.verify;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MultiRabbitBootstrapConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class MultiRabbitBootstrapConfigurationTest {
 
-    private MultiRabbitBootstrapConfiguration configuration = new MultiRabbitBootstrapConfiguration();
+    private final MultiRabbitBootstrapConfiguration configuration = new MultiRabbitBootstrapConfiguration();
 
     @Mock
     private BeanDefinitionRegistry registry;
 
     @Test
-    public void shouldCreateMultiRabbitListenerAnnotationBeanPostProcessorBean() {
+    void shouldCreateMultiRabbitListenerAnnotationBeanPostProcessorBean() {
         configuration.registerBeanDefinitions(null, registry);
 
         verify(registry).registerBeanDefinition(

--- a/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitAdminNameResolverTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/RabbitAdminNameResolverTest.java
@@ -1,19 +1,19 @@
 package org.springframework.amqp.rabbit.annotation;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.autoconfigure.amqp.MultiRabbitConstants;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class RabbitAdminNameResolverTest {
+@ExtendWith(MockitoExtension.class)
+class RabbitAdminNameResolverTest {
 
     private static final String DUMMY_ADMIN = "dummy-admin";
     private static final String DUMMY_CONTAINER_FACTORY = "dummy-container-factory";
@@ -22,7 +22,7 @@ public class RabbitAdminNameResolverTest {
     private RabbitListener listener;
 
     @Test
-    public void shouldResolveFromAdmin() {
+    void shouldResolveFromAdmin() {
         when(listener.admin()).thenReturn(DUMMY_ADMIN);
         assertEquals(DUMMY_ADMIN, RabbitAdminNameResolver.resolve(listener));
 
@@ -31,7 +31,7 @@ public class RabbitAdminNameResolverTest {
     }
 
     @Test
-    public void shouldResolveFromContainerFactoryWhenNoAdminIsAvailable() {
+    void shouldResolveFromContainerFactoryWhenNoAdminIsAvailable() {
         when(listener.containerFactory()).thenReturn(DUMMY_CONTAINER_FACTORY);
         String expected = DUMMY_CONTAINER_FACTORY + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX;
         assertEquals(expected, RabbitAdminNameResolver.resolve(listener));
@@ -41,7 +41,7 @@ public class RabbitAdminNameResolverTest {
     }
 
     @Test
-    public void shouldResolveFallbackToDefault() {
+    void shouldResolveFallbackToDefault() {
         assertEquals(MultiRabbitConstants.DEFAULT_RABBIT_ADMIN_BEAN_NAME, RabbitAdminNameResolver.resolve(listener));
 
         verify(listener, atLeastOnce()).admin();

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ConnectionFactoryContextWrapperTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ConnectionFactoryContextWrapperTest.java
@@ -1,27 +1,21 @@
 package org.springframework.boot.autoconfigure.amqp;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
-
 import java.util.concurrent.Callable;
-
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class ConnectionFactoryContextWrapperTest {
+@ExtendWith(MockitoExtension.class)
+class ConnectionFactoryContextWrapperTest {
 
     private static final String DUMMY_CONTEXT_NAME = "dummy-context-name";
     private static final String DUMMY_RETURN = "dummy-return";
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Mock
     private ConnectionFactory connectionFactory;
@@ -37,7 +31,7 @@ public class ConnectionFactoryContextWrapperTest {
     }
 
     @Test
-    public void shouldCall() throws Exception {
+    void shouldCall() throws Exception {
         when(callable.call()).thenReturn(DUMMY_RETURN);
 
         String result = wrapper().call(DUMMY_CONTEXT_NAME, callable);
@@ -47,17 +41,18 @@ public class ConnectionFactoryContextWrapperTest {
     }
 
     @Test
-    public void shouldNotSuppressExceptionWhenCalling() throws Exception {
-        exception.expect(RuntimeException.class);
-        exception.expectMessage("dummy-exception");
-
+    void shouldNotSuppressExceptionWhenCalling() throws Exception {
         when(callable.call()).thenThrow(new RuntimeException("dummy-exception"));
 
-        wrapper().call(DUMMY_CONTEXT_NAME, callable);
+        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
+            wrapper().call(DUMMY_CONTEXT_NAME, callable);
+        });
+
+        assertEquals("dummy-exception", exception.getMessage());
     }
 
     @Test
-    public void shouldRun() throws Exception {
+    void shouldRun() {
         wrapper().run(DUMMY_CONTEXT_NAME, runnable);
 
         verify(runnable).run();

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ConnectionFactoryContextWrapperTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ConnectionFactoryContextWrapperTest.java
@@ -5,7 +5,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+
 import java.util.concurrent.Callable;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
@@ -42,17 +44,14 @@ class ConnectionFactoryContextWrapperTest {
 
     @Test
     void shouldNotSuppressExceptionWhenCalling() throws Exception {
-        when(callable.call()).thenThrow(new RuntimeException("dummy-exception"));
+        final RuntimeException ex = new RuntimeException("dummy-exception");
+        when(callable.call()).thenThrow(ex);
 
-        RuntimeException exception = assertThrows(RuntimeException.class, () -> {
-            wrapper().call(DUMMY_CONTEXT_NAME, callable);
-        });
-
-        assertEquals("dummy-exception", exception.getMessage());
+        assertThrows(ex.getClass(), () -> wrapper().call(DUMMY_CONTEXT_NAME, callable), ex.getMessage());
     }
 
     @Test
-    void shouldRun() {
+    void shouldRun() throws Exception {
         wrapper().run(DUMMY_CONTEXT_NAME, runnable);
 
         verify(runnable).run();

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfigurationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitAutoConfigurationTest.java
@@ -1,17 +1,17 @@
 package org.springframework.boot.autoconfigure.amqp;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MultiRabbitAutoConfigurationTest {
+@ExtendWith(MockitoExtension.class)
+class MultiRabbitAutoConfigurationTest {
 
     @Mock
     private ConnectionFactory connectionFactory;
@@ -21,12 +21,12 @@ public class MultiRabbitAutoConfigurationTest {
     }
 
     @Test
-    public void shouldInstantiateDefaultRabbitAdmin() {
+    void shouldInstantiateDefaultRabbitAdmin() {
         assertTrue(config().amqpAdmin(connectionFactory) instanceof RabbitAdmin);
     }
 
     @Test
-    public void shouldInstantiateRabbitConnectionFactoryCreator() {
+    void shouldInstantiateRabbitConnectionFactoryCreator() {
         assertNotNull(config().rabbitConnectionFactoryCreator());
     }
 }

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
@@ -2,12 +2,10 @@ package org.springframework.boot.autoconfigure.amqp;
 
 import com.rabbitmq.client.impl.CredentialsProvider;
 import com.rabbitmq.client.impl.CredentialsRefreshService;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
@@ -20,11 +18,12 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ResourceLoader;
-
 import static java.util.Collections.singletonMap;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -32,13 +31,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
-public class MultiRabbitConnectionFactoryCreatorTest {
+@ExtendWith(MockitoExtension.class)
+class MultiRabbitConnectionFactoryCreatorTest {
 
     private static final String DUMMY_KEY = "dummy-key";
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Mock
     private ConfigurableListableBeanFactory beanFactory;
@@ -96,14 +92,14 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateExternalEmptyWrapper() {
+    void shouldInstantiateExternalEmptyWrapper() {
         MultiRabbitConnectionFactoryWrapper emptyWrapper = creator().externalEmptyWrapper();
         assertTrue(emptyWrapper.getConnectionFactories().isEmpty());
         assertNull(emptyWrapper.getDefaultConnectionFactory());
     }
 
     @Test
-    public void shouldInstantiateRoutingConnectionFactory() throws Exception {
+    void shouldInstantiateRoutingConnectionFactory() throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(rabbitProperties, resourceLoader, credentialsProvider,
             credentialsRefreshService, connectionNameStrategy)
         ).thenReturn(new CachingConnectionFactory());
@@ -112,7 +108,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateRoutingConnectionFactoryWithDefaultAndMultipleConnections() throws Exception {
+    void shouldInstantiateRoutingConnectionFactoryWithDefaultAndMultipleConnections() throws Exception {
         when(wrapper.getDefaultConnectionFactory()).thenReturn(connectionFactory0);
         when(wrapper.getConnectionFactories()).thenReturn(singletonMap(DUMMY_KEY, connectionFactory1));
         when(wrapper.getContainerFactories()).thenReturn(singletonMap(DUMMY_KEY, containerFactory));
@@ -129,7 +125,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateRoutingConnectionFactoryWithOnlyDefaultConnectionFactory() throws Exception {
+    void shouldInstantiateRoutingConnectionFactoryWithOnlyDefaultConnectionFactory() throws Exception {
         when(wrapper.getDefaultConnectionFactory()).thenReturn(connectionFactory0);
 
         ConnectionFactory routingConnectionFactory = creator().routingConnectionFactory(rabbitProperties,
@@ -140,7 +136,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateRoutingConnectionFactoryWithOnlyMultipleConnectionFactories() throws Exception {
+    void shouldInstantiateRoutingConnectionFactoryWithOnlyMultipleConnectionFactories() throws Exception {
         when(wrapper.getConnectionFactories()).thenReturn(singletonMap(DUMMY_KEY, connectionFactory0));
         when(wrapper.getContainerFactories()).thenReturn(singletonMap(DUMMY_KEY, containerFactory));
         when(wrapper.getRabbitAdmins()).thenReturn(singletonMap(DUMMY_KEY, rabbitAdmin));
@@ -159,7 +155,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldReachDefaultConnectionFactoryWhenNotBound() throws Exception {
+    void shouldReachDefaultConnectionFactoryWhenNotBound() throws Exception {
         when(wrapper.getDefaultConnectionFactory()).thenReturn(connectionFactory0);
         when(wrapper.getConnectionFactories()).thenReturn(singletonMap(DUMMY_KEY, connectionFactory1));
         when(wrapper.getContainerFactories()).thenReturn(singletonMap(DUMMY_KEY, containerFactory));
@@ -172,7 +168,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldBindAndReachMultiConnectionFactory() throws Exception {
+    void shouldBindAndReachMultiConnectionFactory() throws Exception {
         when(wrapper.getDefaultConnectionFactory()).thenReturn(connectionFactory0);
         when(wrapper.getConnectionFactories()).thenReturn(singletonMap(DUMMY_KEY, connectionFactory1));
         when(wrapper.getContainerFactories()).thenReturn(singletonMap(DUMMY_KEY, containerFactory));
@@ -190,7 +186,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithDefaultConnection() throws Exception {
+    void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithDefaultConnection() throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(rabbitProperties, resourceLoader, credentialsProvider,
             credentialsRefreshService, connectionNameStrategy)
         ).thenReturn(new CachingConnectionFactory());
@@ -199,7 +195,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithMultipleConnections() throws Exception {
+    void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithMultipleConnections() throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(
             any(RabbitProperties.class),
             eq(resourceLoader),
@@ -219,7 +215,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithDefaultAndMultipleConnections()
+    void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithDefaultAndMultipleConnections()
         throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(
             any(RabbitProperties.class),
@@ -241,10 +237,7 @@ public class MultiRabbitConnectionFactoryCreatorTest {
     }
 
     @Test
-    public void shouldEncapsulateExceptionWhenFailingToCreateBean() throws Exception {
-        exception.expect(Exception.class);
-        exception.expectMessage("mocked-exception");
-
+    void shouldEncapsulateExceptionWhenFailingToCreateBean() throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(
             any(RabbitProperties.class),
             eq(resourceLoader),
@@ -253,9 +246,13 @@ public class MultiRabbitConnectionFactoryCreatorTest {
             eq(connectionNameStrategy))
         ).thenThrow(new Exception("mocked-exception"));
 
-        MultiRabbitProperties multiRabbitProperties = new MultiRabbitProperties();
-        multiRabbitProperties.getConnections().put(DUMMY_KEY, secondaryRabbitProperties);
+        Exception exception = assertThrows(Exception.class, () -> {
+            MultiRabbitProperties multiRabbitProperties = new MultiRabbitProperties();
+            multiRabbitProperties.getConnections().put(DUMMY_KEY, secondaryRabbitProperties);
 
-        creator().routingConnectionFactory(rabbitProperties, multiRabbitProperties, wrapper);
+            creator().routingConnectionFactory(rabbitProperties, multiRabbitProperties, wrapper);
+        });
+
+        assertEquals("mocked-exception", exception.getMessage());
     }
 }

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
@@ -1,9 +1,10 @@
 package org.springframework.boot.autoconfigure.amqp;
 
-import com.rabbitmq.client.impl.CredentialsProvider;
-import com.rabbitmq.client.impl.CredentialsRefreshService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import com.rabbitmq.client.impl.CredentialsProvider;
+import com.rabbitmq.client.impl.CredentialsRefreshService;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
@@ -19,7 +20,6 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ResourceLoader;
 import static java.util.Collections.singletonMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -103,8 +103,9 @@ class MultiRabbitConnectionFactoryCreatorTest {
         when(springFactoryCreator.rabbitConnectionFactory(rabbitProperties, resourceLoader, credentialsProvider,
             credentialsRefreshService, connectionNameStrategy)
         ).thenReturn(new CachingConnectionFactory());
+
         assertTrue(creator().routingConnectionFactory(rabbitProperties, multiRabbitProperties, wrapper)
-            instanceof RoutingConnectionFactory);
+                instanceof RoutingConnectionFactory);
     }
 
     @Test
@@ -216,7 +217,7 @@ class MultiRabbitConnectionFactoryCreatorTest {
 
     @Test
     void shouldInstantiateMultiRabbitConnectionFactoryWrapperWithDefaultAndMultipleConnections()
-        throws Exception {
+            throws Exception {
         when(springFactoryCreator.rabbitConnectionFactory(
             any(RabbitProperties.class),
             eq(resourceLoader),
@@ -246,13 +247,12 @@ class MultiRabbitConnectionFactoryCreatorTest {
             eq(connectionNameStrategy))
         ).thenThrow(new Exception("mocked-exception"));
 
-        Exception exception = assertThrows(Exception.class, () -> {
-            MultiRabbitProperties multiRabbitProperties = new MultiRabbitProperties();
-            multiRabbitProperties.getConnections().put(DUMMY_KEY, secondaryRabbitProperties);
+        MultiRabbitProperties multiRabbitProperties = new MultiRabbitProperties();
+        multiRabbitProperties.getConnections().put(DUMMY_KEY, secondaryRabbitProperties);
 
-            creator().routingConnectionFactory(rabbitProperties, multiRabbitProperties, wrapper);
-        });
+        final Executable executable = () -> creator().routingConnectionFactory(rabbitProperties, multiRabbitProperties,
+                wrapper);
 
-        assertEquals("mocked-exception", exception.getMessage());
+        assertThrows(Exception.class, executable, "mocked-exception");
     }
 }

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapperTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapperTest.java
@@ -1,25 +1,21 @@
 package org.springframework.boot.autoconfigure.amqp;
 
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-
-@RunWith(MockitoJUnitRunner.class)
-public class MultiRabbitConnectionFactoryWrapperTest {
+@ExtendWith(MockitoExtension.class)
+class MultiRabbitConnectionFactoryWrapperTest {
 
     private static final String DUMMY_KEY = "dummy-key";
-
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
 
     @Mock
     private ConnectionFactory connectionFactory;
@@ -35,7 +31,7 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldGetDefaultConnectionFactory() {
+    void shouldGetDefaultConnectionFactory() {
         MultiRabbitConnectionFactoryWrapper wrapper = wrapper();
         wrapper.setDefaultConnectionFactory(connectionFactory);
 
@@ -43,7 +39,7 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldSetNullDefaultConnectionFactory() {
+    void shouldSetNullDefaultConnectionFactory() {
         MultiRabbitConnectionFactoryWrapper wrapper = wrapper();
         wrapper.setDefaultConnectionFactory(null);
 
@@ -51,7 +47,7 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldAddConnectionFactory() {
+    void shouldAddConnectionFactory() {
         MultiRabbitConnectionFactoryWrapper wrapper = wrapper();
         wrapper.addConnectionFactory(DUMMY_KEY, connectionFactory);
 
@@ -61,7 +57,7 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldAddConnectionFactoryWithContainerFactory() {
+    void shouldAddConnectionFactoryWithContainerFactory() {
         MultiRabbitConnectionFactoryWrapper wrapper = wrapper();
         wrapper.addConnectionFactory(DUMMY_KEY, connectionFactory, containerFactory);
 
@@ -71,7 +67,7 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldAddConnectionFactoryWithContainerFactoryAndRabbitAdmin() {
+    void shouldAddConnectionFactoryWithContainerFactoryAndRabbitAdmin() {
         MultiRabbitConnectionFactoryWrapper wrapper = wrapper();
         wrapper.addConnectionFactory(DUMMY_KEY, connectionFactory, containerFactory, rabbitAdmin);
 
@@ -81,16 +77,20 @@ public class MultiRabbitConnectionFactoryWrapperTest {
     }
 
     @Test
-    public void shouldNotAddNullConnectionFactory() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("ConnectionFactory may not be null");
-        wrapper().addConnectionFactory(DUMMY_KEY, null, containerFactory, rabbitAdmin);
+    void shouldNotAddNullConnectionFactory() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            wrapper().addConnectionFactory(DUMMY_KEY, null, containerFactory, rabbitAdmin);
+        });
+
+        assertEquals("ConnectionFactory may not be null", exception.getMessage());
     }
 
     @Test
-    public void shouldNotAddConnectionFactoryWithEmptyKey() {
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("Key may not be null or empty");
-        wrapper().addConnectionFactory("", connectionFactory, containerFactory, rabbitAdmin);
+    void shouldNotAddConnectionFactoryWithEmptyKey() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            wrapper().addConnectionFactory("", connectionFactory, containerFactory, rabbitAdmin);
+        });
+
+        assertEquals("Key may not be null or empty", exception.getMessage());
     }
 }

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapperTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapperTest.java
@@ -2,12 +2,13 @@ package org.springframework.boot.autoconfigure.amqp;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -26,7 +27,7 @@ class MultiRabbitConnectionFactoryWrapperTest {
     @Mock
     private RabbitAdmin rabbitAdmin;
 
-    public MultiRabbitConnectionFactoryWrapper wrapper() {
+    private MultiRabbitConnectionFactoryWrapper wrapper() {
         return new MultiRabbitConnectionFactoryWrapper();
     }
 
@@ -78,19 +79,15 @@ class MultiRabbitConnectionFactoryWrapperTest {
 
     @Test
     void shouldNotAddNullConnectionFactory() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            wrapper().addConnectionFactory(DUMMY_KEY, null, containerFactory, rabbitAdmin);
-        });
-
-        assertEquals("ConnectionFactory may not be null", exception.getMessage());
+        final Executable executable =
+                () -> wrapper().addConnectionFactory(DUMMY_KEY, null, containerFactory, rabbitAdmin);
+        assertThrows(IllegalArgumentException.class, executable, "ConnectionFactory may not be null");
     }
 
     @Test
     void shouldNotAddConnectionFactoryWithEmptyKey() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            wrapper().addConnectionFactory("", connectionFactory, containerFactory, rabbitAdmin);
-        });
-
-        assertEquals("Key may not be null or empty", exception.getMessage());
+        final Executable executable =
+                () -> wrapper().addConnectionFactory("", connectionFactory, containerFactory, rabbitAdmin);
+        assertThrows(IllegalArgumentException.class, executable, "Key may not be null or empty");
     }
 }


### PR DESCRIPTION
Hi @rwanderc.

Opening this PR to add compatibility with Spring Boot 2.4.3.

`RabbitConnectionFactoryCreator` on `rabbitConnectionFactory` is now receiving new arguments. So I've injected it from spring-multirabbit side.

Other than that, I've migrated the unit tests from JUnit 4 to JUnit 5 as [Spring Boot 2.4.3 removed Junit 4 support](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test).