### PR TITLE
#54 - Fixed issue that prevents creating new queues, exchangers and/or bindings.

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: CI
 
 on:
   push:
@@ -13,18 +13,71 @@ on:
       - develop/**
 
 jobs:
-  java:
+  build:
+    if: ${{ !startsWith(github.event.head_commit.message, '[maven-release-plugin] prepare') }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 14 ]
-    name: Java ${{ matrix.java }}
+        java: [ 8 ]
+    name: Build on Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
           java-version: ${{ matrix.java }}
           architecture: x64
+
       - run: java -version
-      - run: mvn -B -U verify
+      - run: mvn -v
+      - run: mvn -B verify -Dgpg.skip=true
+
+  release:
+    if: contains(github.ref, 'release') && startsWith(github.event.head_commit.message, '[release]')
+    runs-on: ubuntu-latest
+    needs: [build]
+    name: Release
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Set env.BRANCH_NAME
+        run: echo "BRANCH_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Release and Publish
+        uses: qcastel/github-actions-maven-release@v1.12.25
+        with:
+          release-branch-name: ${{ env.BRANCH_NAME }}
+
+          gpg-enabled: true
+          gpg-key-id: ${{ secrets.FREE_NOW_GPG_KEY_ID }}
+          gpg-key: ${{ secrets.FREE_NOW_GPG_KEY }}
+          gpg-passphrase: ${{ secrets.FREE_NOW_GPG_PASSPHRASE }}
+
+          ssh-private-key: ${{ secrets.FREE_NOW_GITHUB_PRIVATE_KEY }}
+
+          git-release-bot-name: "free-now-github"
+          git-release-bot-email: "70742378+free-now-github@users.noreply.github.com"
+          git-skip-sanity-check: true
+
+          maven-repo-server-id: ossrh
+          maven-repo-server-username: ${{ secrets.FREE_NOW_GITHUB_USER }}
+          maven-repo-server-password: ${{ secrets.FREE_NOW_MAVEN_ACCESS_TOKEN }}
+          maven-args: "-DskipTests -DskipITs"
+
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk/

--- a/pom.xml
+++ b/pom.xml
@@ -10,12 +10,19 @@
 
     <name>Spring MultiRabbit</name>
     <description>Library to extend Spring to provide connection to multiple RabbitMQ servers</description>
+    <url>https://github.com/freenowtech/spring-multirabbit</url>
 
-    <url>http://www.free-now.com</url>
+    <modules>
+        <module>spring-multirabbit</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-example-java</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-example-kotlin</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-extension-example</module>
+    </modules>
+
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 
@@ -26,33 +33,41 @@
         </developer>
     </developers>
 
-    <modules>
-        <module>spring-multirabbit</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-example-java</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-example-kotlin</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-extension-example</module>
-    </modules>
+    <scm>
+        <connection>scm:git:git@github.com:freenowtech/spring-multirabbit.git</connection>
+        <developerConnection>scm:git:git@github.com:freenowtech/spring-multirabbit.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>scm:git:git@github.com:freenowtech/spring-multirabbit.git</url>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.4.0</springboot.version>
-    </properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
 
-    <scm>
-        <tag>HEAD</tag>
-        <url>scm:git:https://github.com/freenowtech/spring-multirabbit.git</url>
-        <connection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</connection>
-        <developerConnection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</developerConnection>
-    </scm>
-    <distributionManagement>
-        <repository>
-            <id>bintray-mytaxi-oss</id>
-            <name>mytaxi-oss</name>
-            <url>https://api.bintray.com/maven/mytaxi/oss/spring-multirabbit/;publish=1</url>
-        </repository>
-    </distributionManagement>
+        <springboot.version>2.4.0</springboot.version>
+        <testcontainers-rabbitmq.version>1.15.2</testcontainers-rabbitmq.version>
+
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -69,24 +84,38 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven-gpg-plugin.version}</version>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -99,7 +128,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -110,9 +139,29 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <configLocation>oss-checkstyle.xml</configLocation>
                     <sourceDirectories>${project.basedir}</sourceDirectories>

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/main/java/com/freenow/multirabbit/example/extension/ExtendedConfiguration.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/main/java/com/freenow/multirabbit/example/extension/ExtendedConfiguration.java
@@ -16,8 +16,6 @@ public class ExtendedConfiguration {
     static final String EXTENDED_CONNECTION_B = "extendedConnectionNameB";
     static final String EXTENDED_CONNECTION_C = "extendedConnectionNameC";
 
-    static final String EXTENDED_CONNECTION_C_ADMIN_ALIAS_1 = "anotherAdminBeanName";
-    static final String EXTENDED_CONNECTION_C_ADMIN_ALIAS_2 = "anotherOtherAdminBeanName";
     static final int CONNECTION_TIMEOUT = 50;
 
     @Bean
@@ -29,8 +27,7 @@ public class ExtendedConfiguration {
         final RabbitAdmin sharedAdmin = newRabbitAdmin(connA);
         wrapper.addConnectionFactory(EXTENDED_CONNECTION_A, connA, newContainerFactory(connA), sharedAdmin);
         wrapper.addConnectionFactory(EXTENDED_CONNECTION_B, connB, newContainerFactory(connB), newRabbitAdmin(connB));
-        wrapper.addConnectionFactory(EXTENDED_CONNECTION_C, connC, newContainerFactory(connC), sharedAdmin,
-                EXTENDED_CONNECTION_C_ADMIN_ALIAS_1, EXTENDED_CONNECTION_C_ADMIN_ALIAS_2);
+        wrapper.addConnectionFactory(EXTENDED_CONNECTION_C, connC, newContainerFactory(connC), sharedAdmin);
         wrapper.setDefaultConnectionFactory(connA);
         return wrapper;
     }

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/extension/ApplicationTest.java
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/src/test/java/com/freenow/multirabbit/example/extension/ApplicationTest.java
@@ -18,8 +18,6 @@ import java.util.List;
 import static com.freenow.multirabbit.example.extension.ExtendedConfiguration.EXTENDED_CONNECTION_A;
 import static com.freenow.multirabbit.example.extension.ExtendedConfiguration.EXTENDED_CONNECTION_B;
 import static com.freenow.multirabbit.example.extension.ExtendedConfiguration.EXTENDED_CONNECTION_C;
-import static com.freenow.multirabbit.example.extension.ExtendedConfiguration.EXTENDED_CONNECTION_C_ADMIN_ALIAS_1;
-import static com.freenow.multirabbit.example.extension.ExtendedConfiguration.EXTENDED_CONNECTION_C_ADMIN_ALIAS_2;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -65,15 +63,5 @@ class ApplicationTest {
                 EXTENDED_CONNECTION_B + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX,
                 EXTENDED_CONNECTION_C + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX);
         beans.forEach(bean -> assertNotNull(applicationContext.getBean(bean, RabbitAdmin.class)));
-    }
-
-    @Test
-    void shouldResolveRabbitAdminAliases() {
-        final RabbitAdmin admin = applicationContext.getBean(
-                EXTENDED_CONNECTION_C + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX, RabbitAdmin.class);
-        Assertions.assertThat(admin).isSameAs(applicationContext.getBean(EXTENDED_CONNECTION_C_ADMIN_ALIAS_1,
-                RabbitAdmin.class));
-        Assertions.assertThat(admin).isSameAs(applicationContext.getBean(EXTENDED_CONNECTION_C_ADMIN_ALIAS_2,
-                RabbitAdmin.class));
     }
 }

--- a/spring-multirabbit/pom.xml
+++ b/spring-multirabbit/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.free-now.multirabbit</groupId>
         <artifactId>spring-multirabbit-parent</artifactId>
         <version>2.4.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-multirabbit</artifactId>
 
     <name>Spring MultiRabbit Library</name>
     <description>Library to extend Spring to provide connection to multiple RabbitMQ servers</description>
+    <url>https://github.com/freenowtech/spring-multirabbit</url>
 
     <dependencies>
         <dependency>
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>rabbitmq</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers-rabbitmq.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -63,12 +63,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>

--- a/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapper.java
+++ b/spring-multirabbit/src/main/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryWrapper.java
@@ -4,12 +4,9 @@ import org.springframework.amqp.rabbit.config.AbstractRabbitListenerContainerFac
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitAdmin;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static java.util.stream.Collectors.toMap;
 import static org.springframework.util.Assert.hasText;
@@ -85,36 +82,18 @@ public class MultiRabbitConnectionFactoryWrapper {
     /**
      * Adds a {@link ConnectionFactory} associated to a ContainerFactory and a RabbitAdmin.
      *
-     * @param key               The key for the structures.
-     * @param connectionFactory The {@link ConnectionFactory}.
-     * @param containerFactory  The related
-     *                          {@link org.springframework.amqp.rabbit.config.AbstractRabbitListenerContainerFactory}.
-     * @param rabbitAdmin       The related {@link RabbitAdmin}.
-     */
-    public void addConnectionFactory(final String key,
-                                     final ConnectionFactory connectionFactory,
-                                     final AbstractRabbitListenerContainerFactory<?> containerFactory,
-                                     final RabbitAdmin rabbitAdmin) {
-        addConnectionFactory(key, connectionFactory, containerFactory, rabbitAdmin, null);
-    }
-
-    /**
-     * Adds a {@link ConnectionFactory} associated to a ContainerFactory and a RabbitAdmin.
-     *
      * @param key                The key for the structures.
      * @param connectionFactory  The {@link ConnectionFactory}.
      * @param containerFactory   The related
      *                           {@link org.springframework.amqp.rabbit.config.AbstractRabbitListenerContainerFactory}.
      * @param rabbitAdmin        The related {@link RabbitAdmin}.
-     * @param rabbitAdminAliases The aliases for the {@link RabbitAdmin}.
      */
     public void addConnectionFactory(final String key,
                                      final ConnectionFactory connectionFactory,
                                      final AbstractRabbitListenerContainerFactory<?> containerFactory,
-                                     final RabbitAdmin rabbitAdmin,
-                                     final String... rabbitAdminAliases) {
+                                     final RabbitAdmin rabbitAdmin) {
         hasText(key, "Key may not be null or empty");
-        entries.put(key, new Entry(connectionFactory, containerFactory, rabbitAdmin, rabbitAdminAliases));
+        entries.put(key, new Entry(connectionFactory, containerFactory, rabbitAdmin));
     }
 
     /**
@@ -144,7 +123,6 @@ public class MultiRabbitConnectionFactoryWrapper {
         private final ConnectionFactory connectionFactory;
         private final AbstractRabbitListenerContainerFactory<?> containerFactory;
         private final RabbitAdmin rabbitAdmin;
-        private final Set<String> rabbitAdminAliases;
 
         /**
          * Returns an entry containing the triple for the wrapper.
@@ -155,8 +133,7 @@ public class MultiRabbitConnectionFactoryWrapper {
          */
         private Entry(final ConnectionFactory connectionFactory,
                       final AbstractRabbitListenerContainerFactory<?> containerFactory,
-                      final RabbitAdmin rabbitAdmin,
-                      final String... rabbitAdminAliases) {
+                      final RabbitAdmin rabbitAdmin) {
             notNull(connectionFactory, "ConnectionFactory may not be null");
             if (containerFactory != null) {
                 containerFactory.setConnectionFactory(connectionFactory);
@@ -164,9 +141,6 @@ public class MultiRabbitConnectionFactoryWrapper {
             this.connectionFactory = connectionFactory;
             this.containerFactory = containerFactory;
             this.rabbitAdmin = rabbitAdmin;
-            this.rabbitAdminAliases = rabbitAdminAliases != null
-                    ? new HashSet<>(Arrays.asList(rabbitAdminAliases))
-                    : Collections.emptySet();
         }
 
         /**
@@ -194,15 +168,6 @@ public class MultiRabbitConnectionFactoryWrapper {
          */
         RabbitAdmin getRabbitAdmin() {
             return rabbitAdmin;
-        }
-
-        /**
-         * Returns the {@link Set} of aliases to be used for registering the {@link RabbitAdmin}.
-         *
-         * @return the {@link Set} of aliases.
-         */
-        Set<String> getRabbitAdminAliases() {
-            return rabbitAdminAliases;
         }
     }
 }

--- a/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitDeclarationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/amqp/rabbit/annotation/MultiRabbitDeclarationTest.java
@@ -16,7 +16,7 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.stereotype.Component;
 import org.testcontainers.containers.RabbitMQContainer;
 
-public class MultiRabbitDeclarationTest {
+class MultiRabbitDeclarationTest {
 
     private final RabbitMQContainer defaultRabbit = new RabbitMQContainer("rabbitmq:3-management");
     private final RabbitMQContainer rabbit1 = new RabbitMQContainer("rabbitmq:3-management");

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/ExternalConfigurationTest.java
@@ -91,7 +91,7 @@ class ExternalConfigurationTest {
                     assertThat(defaultRabbitAdmin).isNotNull();
                     assertThat(broker1Admin).isNotNull();
                     assertThat(broker2Admin).isNotNull();
-                    assertThat(externalAdmin).isSameAs(ExternalConfig.RABBIT_ADMIN);
+                    assertThat(externalAdmin).isInstanceOf(RabbitAdmin.class);
 
                     final RabbitListenerContainerFactory defaultContainerFactory = context.getBean(
                             MultiRabbitConstants.DEFAULT_CONTAINER_FACTORY_BEAN_NAME,
@@ -123,23 +123,6 @@ class ExternalConfigurationTest {
                 });
     }
 
-    @Test
-    @DisplayName("should register additional aliases for external integration")
-    void shouldRegisterAdditionalAliasesFromExternalIntegration() {
-        this.contextRunner
-                .withPropertyValues("spring.multirabbitmq.enabled=true")
-                .run((context) -> {
-                    final RabbitAdmin externalAdmin = context.getBean(
-                            ExternalConfig.CONNECTION_KEY.concat(MultiRabbitConstants.RABBIT_ADMIN_SUFFIX),
-                            RabbitAdmin.class);
-                    final RabbitAdmin alias1 = context.getBean(ExternalConfig.RABBIT_ALIAS_1, RabbitAdmin.class);
-                    final RabbitAdmin alias2 = context.getBean(ExternalConfig.RABBIT_ALIAS_2, RabbitAdmin.class);
-                    assertThat(externalAdmin).isSameAs(ExternalConfig.RABBIT_ADMIN);
-                    assertThat(alias1).isSameAs(externalAdmin);
-                    assertThat(alias2).isSameAs(externalAdmin);
-                });
-    }
-
     @Configuration
     @Import(MultiRabbitAutoConfiguration.class)
     static class ExternalConfig {
@@ -150,15 +133,12 @@ class ExternalConfigurationTest {
                 = mock(SimpleRabbitListenerContainerFactory.class);
         private static final RabbitAdmin RABBIT_ADMIN = mock(RabbitAdmin.class);
         private static final ConnectionFactory DEFAULT_CONNECTION_FACTORY = mock(ConnectionFactory.class);
-        private static final String RABBIT_ALIAS_1 = "rabbitAlias1";
-        private static final String RABBIT_ALIAS_2 = "rabbitAlias2";
 
         @Bean
         @ConditionalOnClass(MultiRabbitConnectionFactoryWrapper.class)
         static MultiRabbitConnectionFactoryWrapper externalWrapper() {
             final MultiRabbitConnectionFactoryWrapper wrapper = new MultiRabbitConnectionFactoryWrapper();
-            wrapper.addConnectionFactory(CONNECTION_KEY, CONNECTION_FACTORY, CONTAINER_FACTORY, RABBIT_ADMIN,
-                    RABBIT_ALIAS_1, RABBIT_ALIAS_2);
+            wrapper.addConnectionFactory(CONNECTION_KEY, CONNECTION_FACTORY, CONTAINER_FACTORY, RABBIT_ADMIN);
             wrapper.setDefaultConnectionFactory(DEFAULT_CONNECTION_FACTORY);
             return wrapper;
         }

--- a/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
+++ b/spring-multirabbit/src/test/java/org/springframework/boot/autoconfigure/amqp/MultiRabbitConnectionFactoryCreatorTest.java
@@ -120,8 +120,9 @@ class MultiRabbitConnectionFactoryCreatorTest {
 
         assertTrue(routingConnectionFactory instanceof SimpleRoutingConnectionFactory);
         verify(beanFactory).registerSingleton(DUMMY_KEY, containerFactory);
-        verify(beanFactory).registerSingleton(DUMMY_KEY + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX,
-                rabbitAdmin);
+        verify(beanFactory).registerSingleton(
+            eq(DUMMY_KEY + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX), any(RabbitAdmin.class)
+        );
         verifyNoMoreInteractions(beanFactory);
     }
 
@@ -153,8 +154,9 @@ class MultiRabbitConnectionFactoryCreatorTest {
 
         assertTrue(routingConnectionFactory instanceof SimpleRoutingConnectionFactory);
         verify(beanFactory).registerSingleton(DUMMY_KEY, containerFactory);
-        verify(beanFactory).registerSingleton(DUMMY_KEY + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX,
-                rabbitAdmin);
+        verify(beanFactory).registerSingleton(
+            eq(DUMMY_KEY + MultiRabbitConstants.RABBIT_ADMIN_SUFFIX), any(RabbitAdmin.class)
+        );
         verifyNoMoreInteractions(beanFactory);
     }
 


### PR DESCRIPTION
There was a problem registering the Admins. It was being overwritten as we were using its reference instead of a new instance.
In addition, the bean name was being set after calling afterPropertiesSet, which caused the registered bean to have no name. 
Those two problems cause that during the declaration of the queues, exchange or bindings, the registered RabbitAdmin was not identified as DeclarableAdmins.

More info on how RabbitAdmin filter the declarebles here: RabbitAdmin.filterDeclarables(.....) and the admin checks here: declarableByMe(...)

Introducing Github Actions to build, release and publishing artifacts to maven central