### PR TITLE
Github Actions to build, release and publishing artefacts to maven central

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven
+name: Java CI
 
 on:
   push:
@@ -13,19 +13,70 @@ on:
       - develop/**
 
 jobs:
-  java:
+  build:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11 ]
+        java: [ 8 ]
     name: Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
       - name: Setup java
         uses: joschi/setup-jdk@v2
         with:
           java-version: ${{ matrix.java }}
           architecture: x64
+
       - run: java -version
       - run: mvn -v
-      - run: mvn -B verify
+      - run: mvn -B verify -Dgpg.skip=true
+
+  release:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if:  contains(github.ref, 'release') && startsWith(github.event.head_commit.message, '[release]')
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v2
+
+      - name: Setup Java 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+
+      - name: Cache Maven packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+
+      - name: Get branch name
+        uses: nelonoel/branch-name@v1.0.1
+
+      - name: Release and Publish
+        uses: qcastel/github-actions-maven-release@v1.12.25
+        with:
+          release-branch-name: ${{ env.BRANCH_NAME }}
+
+          gpg-enabled: true
+          gpg-key-id: ${{ secrets.FREE_NOW_GPG_KEY_ID }}
+          gpg-key: ${{ secrets.FREE_NOW_GPG_KEY }}
+          gpg-passphrase: ${{ secrets.FREE_NOW_GPG_PASSPHRASE }}
+
+          ssh-private-key: ${{ secrets.FREE_NOW_GITHUB_PRIVATE_KEY }}
+
+          git-release-bot-name: "free-now-github"
+          git-release-bot-email: "70742378+free-now-github@users.noreply.github.com"
+
+          access-token: ${{ secrets.FREE_NOW_GITHUB_ACCESS_TOKEN }}
+
+          maven-repo-server-id: ossrh
+          maven-repo-server-username: ${{ secrets.FREE_NOW_GITHUB_USER }}
+          maven-repo-server-password: ${{ secrets.FREE_NOW_MAVEN_ACCESS_TOKEN }}
+          maven-args: "-DskipTests -DskipITs"
+
+        env:
+          JAVA_HOME: /usr/lib/jvm/java-1.8-openjdk/

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       matrix:
         java: [ 8 ]
-    name: Java ${{ matrix.java }}
+    name: Build on Java ${{ matrix.java }}
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/pom.xml
+++ b/pom.xml
@@ -5,17 +5,25 @@
 
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-parent</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Spring MultiRabbit</name>
     <description>Library to extend Spring to provide connection to multiple RabbitMQ servers</description>
+    <url>https://github.com/freenowtech/spring-multirabbit</url>
 
-    <url>http://www.free-now.com</url>
+    <modules>
+        <module>spring-multirabbit</module>
+        <module>spring-multirabbit-integration</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-example-java</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-example-kotlin</module>
+        <module>spring-multirabbit-examples/spring-multirabbit-extension-example</module>
+    </modules>
+
     <licenses>
         <license>
             <name>Apache License Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
 
@@ -26,34 +34,41 @@
         </developer>
     </developers>
 
-    <modules>
-        <module>spring-multirabbit</module>
-        <module>spring-multirabbit-integration</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-example-java</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-example-kotlin</module>
-        <module>spring-multirabbit-examples/spring-multirabbit-extension-example</module>
-    </modules>
+    <scm>
+        <connection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</connection>
+        <developerConnection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>scm:git:https://github.com/freenowtech/spring-multirabbit.git</url>
+    </scm>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <springboot.version>2.3.9.RELEASE</springboot.version>
-    </properties>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <java.version>1.8</java.version>
 
-    <scm>
-        <tag>HEAD</tag>
-        <url>scm:git:https://github.com/freenowtech/spring-multirabbit.git</url>
-        <connection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</connection>
-        <developerConnection>scm:git:https://github.com/freenowtech/spring-multirabbit.git</developerConnection>
-    </scm>
-    <distributionManagement>
-        <repository>
-            <id>bintray-mytaxi-oss</id>
-            <name>mytaxi-oss</name>
-            <url>https://api.bintray.com/maven/mytaxi/oss/spring-multirabbit/;publish=1</url>
-        </repository>
-    </distributionManagement>
+        <springboot.version>2.3.9.RELEASE</springboot.version>
+        <testcontainers-rabbitmq.version>1.15.2</testcontainers-rabbitmq.version>
+
+        <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
+        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
+        <maven-source-plugin.version>3.2.1</maven-source-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.8</nexus-staging-maven-plugin.version>
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -70,24 +85,38 @@
     <build>
         <plugins>
             <plugin>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin.version}</version>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>${maven-surefire-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>${maven-gpg-plugin.version}</version>
+                <configuration>
+                    <gpgArguments>
+                        <arg>--pinentry-mode</arg>
+                        <arg>loopback</arg>
+                    </gpgArguments>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sign-artifacts</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>sign</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-source-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -100,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.0.1</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -111,9 +140,29 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>${nexus-staging-maven-plugin.version}</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <configuration>
                     <configLocation>oss-checkstyle.xml</configLocation>
                     <sourceDirectories>${project.basedir}</sourceDirectories>

--- a/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-java/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-example-java</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring MultiRabbit Example for Java</name>

--- a/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-example-kotlin/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-example-kotlin</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring MultiRabbit Example for Kotlin</name>

--- a/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
+++ b/spring-multirabbit-examples/spring-multirabbit-extension-example/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-extended-example-java</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring MultiRabbit Extension Example</name>

--- a/spring-multirabbit-integration/pom.xml
+++ b/spring-multirabbit-integration/pom.xml
@@ -12,7 +12,7 @@
 
     <groupId>com.free-now.multirabbit</groupId>
     <artifactId>spring-multirabbit-integration</artifactId>
-    <version>2.3.2-SNAPSHOT</version>
+    <version>2.3.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring MultiRabbit Library Integration Tests</name>

--- a/spring-multirabbit/pom.xml
+++ b/spring-multirabbit/pom.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>com.free-now.multirabbit</groupId>
         <artifactId>spring-multirabbit-parent</artifactId>
-        <version>2.3.2-SNAPSHOT</version>
-        <relativePath>../</relativePath>
+        <version>2.3.4-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>spring-multirabbit</artifactId>
 
     <name>Spring MultiRabbit Library</name>
     <description>Library to extend Spring to provide connection to multiple RabbitMQ servers</description>
+    <url>https://github.com/freenowtech/spring-multirabbit</url>
 
     <dependencies>
         <dependency>
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>rabbitmq</artifactId>
-            <version>1.15.2</version>
+            <version>${testcontainers-rabbitmq.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -58,12 +58,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
-                    <source>8</source>
-                    <target>8</target>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
 </project>


### PR DESCRIPTION
This is the Github Action to build, release and publish the artifacts to maven central.
This action has two jobs:
#### Build  
Runs every time we have a push or PR to one of these branches: main, develop/** or release/**.   

#### Release  
This job will be triggered after build(if successfully finished) and on these conditions:

- If the branch name contains release - as we publish only on release branches
- If the commit message starts with '**[release]**' - to make sure we are ready to publish 

Once the conditions above are satisfied, we proceed with the release steps:
- Checkout source code
- Setup java version
- Cache  maven packages
- Get the branch name - required in the next step
- Release and Publish - here is where we generate the required artifacts, they are signed, published to maven, and the next dev version is prepared.

Important notes:
- To trigger the release, we need to make sure that our **commit message has the prefix: [release]**
- Why not two different files, one for build and one for release? This is to keep the results on the Actions tab clean. As we would have one entry to build and another to release for every single push or PR. This way we will have only one Action - Java CI and inside this action, we can clearly see the execution of the Jobs Build and Release. 

Additionally to the actions, we have some changes in the pom files to generate the required artifacts, sign them, and connect to maven central.